### PR TITLE
Update trappist_gravity_model_slippist1.cfg

### DIFF
--- a/astronomy/trappist_gravity_model_slippist1.cfg
+++ b/astronomy/trappist_gravity_model_slippist1.cfg
@@ -4,7 +4,7 @@
       !mass = delete
       @displayName = Trappist-1
       %gravParameter = +1.18114071600000000e+19
-      %radius = +8.41797000000000000e+07
+      %radius = +8.41796999999999971e+07
       %description = An ultra-cool red dwarf star of spectral type M8 V, 40 light-years from Earth; also known as 2MUCD 12171 and 2MASS J23062928-0502285.
     }
     @ScaledVersion {
@@ -26,8 +26,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1b
-      %gravParameter = +4.05376606799999938e+14
-      %radius = +6.44188100000000000e+06
+      %gravParameter = +4.05376606799999950e+14
+      %radius = +6.44188100000000031e+06
       %description = Requires envelope of volatiles in the form of a thick atmosphere.  Above the runaway greenhouse limit.
       %tidallyLocked = false
     }
@@ -56,8 +56,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1c
-      %gravParameter = +4.60782062399999938e+14
-      %radius = +6.76078600000000000e+06
+      %gravParameter = +4.60782062399999937e+14
+      %radius = +6.76078600000000006e+06
       %description = Likely has a rocky interior.
       %tidallyLocked = false
     }
@@ -86,8 +86,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1d
-      %gravParameter = +1.18384318800000000e+14
-      %radius = +5.00043040000000037e+06
+      %gravParameter = +1.18384318799999994e+14
+      %radius = +5.00043040000000019e+06
       %description = Requires envelope of volatiles in the form of a thick atmosphere, oceans or ice.
       %tidallyLocked = false
     }
@@ -116,8 +116,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1e
-      %gravParameter = +3.07719508800000000e+14
-      %radius = +5.80407100000000000e+06
+      %gravParameter = +3.07719508800000011e+14
+      %radius = +5.80407099999999991e+06
       %description = Likely has a rocky interior.
       %tidallyLocked = false
     }
@@ -146,8 +146,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1f
-      %gravParameter = +3.72292773600000000e+14
-      %radius = +6.67149260000000056e+06
+      %gravParameter = +3.72292773600000015e+14
+      %radius = +6.67149260000000049e+06
       %description = Requires envelope of volatiles in the form of oceans or ice.
       %tidallyLocked = false
     }
@@ -176,8 +176,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1g
-      %gravParameter = +4.57593259199999938e+14
-      %radius = +7.32205879999999981e+06
+      %gravParameter = +4.57593259199999913e+14
+      %radius = +7.32205879999999979e+06
       %description = Requires envelope of volatiles in the form of oceans or ice.
       %tidallyLocked = false
     }
@@ -206,8 +206,8 @@
     @Properties {
       !geeASL = delete
       @displayName = Trappist-1h
-      %gravParameter = +1.31936732400000000e+14
-      %radius = +4.93027129999999981e+06
+      %gravParameter = +1.31936732400000008e+14
+      %radius = +4.93027129999999943e+06
       %description = Requires envelope of volatiles in the form of oceans or ice.
       %tidallyLocked = false
     }


### PR DESCRIPTION
File created to check if the numerical value differences are large enough to be significant:

For  "[trappist-1 for principia fáry](https://github.com/mockingbirdnest/Principia/wiki/Installing,-reporting-bugs,-and-frequently-asked-questions#installing-trappist-1-for-principia)"

Many of the %gravParameter & %radius parameters in the current "trappist_gravity_model_slippist1.cfg" do not match the values in "trappist_gravity_model.cfg"

Reference Issue: #1999

Commit f9c2608... on Dec 31, 2018
Kopernicus configuration.
[https://github.com/mockingbirdnest/Principia/commit/f9c260813347feca3e15c081b322e0b5c1640d01#diff-597cfb7887856e487fa742e0fee5d4e3](url)

